### PR TITLE
Inline option, date incorrect

### DIFF
--- a/addon/components/date-time-picker.js
+++ b/addon/components/date-time-picker.js
@@ -57,11 +57,11 @@ const DateTimePickerComponent = Ember.Component.extend({
     let changeHandler = this.get('_changeHandlerProxy');
     let options = this.get('options') || {};
 
+    this._updateValue();
+
     this.$()
       .datetimepicker(options)
       .on('change', changeHandler);
-
-    this._updateValue();
   }
 });
 

--- a/tests/dummy/app/controllers/application.js
+++ b/tests/dummy/app/controllers/application.js
@@ -2,6 +2,7 @@ import Ember from 'ember';
 
 export default Ember.Controller.extend({
   initialDatetime: new Date(),
+  datetime: new Date('12/25/1994'),
   options: {
     inline: true
   },


### PR DESCRIPTION
The date when the calendar has the "inline" option set to true for the
datetimepicker plugin was not rendering the correct date.  This was
happening because the input value wasn't set before applying.